### PR TITLE
Fix DPA crash issues: 1. PRM thread create fail 2. Destory vq memory …

### DIFF
--- a/dpa/device/vrdma_dpa_db.c
+++ b/dpa/device/vrdma_dpa_db.c
@@ -19,8 +19,9 @@
 #include "vrdma_dpa_dev_com.h"
 #include "vrdma_dpa_cq.h"
 
-#define DPA_DEBUG
-#define DPA_DEBUG_DETAIL
+//#define DPA_LATENCY_TEST
+//#define DPA_DEBUG
+//#define DPA_DEBUG_DETAIL
 // #define DPA_COUNT
 
 static int get_next_qp_swqe_index(uint32_t pi, uint32_t depth)
@@ -183,7 +184,7 @@ void vrdma_db_handler(flexio_uintptr_t thread_arg)
 	ehctx = (struct vrdma_dpa_event_handler_ctx *)thread_arg;
 //	printf("%s: --------virtq status %d.\n", __func__, ehctx->dma_qp.state);
 	if (ehctx->dma_qp.state != VRDMA_DPA_VQ_STATE_RDY) {
-		printf("%s: ------virtq status %d is not READY.\n", __func__, ehctx->dma_qp.state);
+		//printf("%s: ------virtq status %d is not READY.\n", __func__, ehctx->dma_qp.state);
 		goto out;
 	}
 	flexio_dev_outbox_config(dtctx, ehctx->emu_outbox);
@@ -217,10 +218,12 @@ void vrdma_db_handler(flexio_uintptr_t thread_arg)
 
 	rq_last_fetch_end = rq_pi % ehctx->dma_qp.host_vq_ctx.rq_wqebb_cnt;
 	sq_last_fetch_end = sq_pi % ehctx->dma_qp.host_vq_ctx.sq_wqebb_cnt;
-
+#ifdef DPA_LATENCY_TEST
+	while (1)
+#else
 	while ((rq_last_fetch_start != rq_last_fetch_end) || 
 	 	(sq_last_fetch_start != sq_last_fetch_end))
-	//while (1)
+#endif
 	{
 		if (rq_last_fetch_start < rq_last_fetch_end) {
 			has_wqe = vrdma_dpa_rq_wr_pi_fetch(ehctx, rq_last_fetch_start, rq_last_fetch_end, rq_pi);

--- a/dpa/host/vrdma_dpa.h
+++ b/dpa/host/vrdma_dpa.h
@@ -20,7 +20,7 @@
 #include "lib/vrdma/vrdma_providers.h"
 #include "dpa/vrdma_dpa_common.h"
 
-#define VRDMA_MAX_CORES_AVAILABLE 12
+#define VRDMA_MAX_CORES_AVAILABLE 10
 #define VRDMA_MAX_HARTS_PER_CORE  16
 
 #define VRDMA_DPA_RPC_UNPACK_FUNC "vrdma_dpa_rpc_unpack_func"

--- a/dpa/host/vrdma_dpa_vq.c
+++ b/dpa/host/vrdma_dpa_vq.c
@@ -766,8 +766,10 @@ static void _vrdma_dpa_vq_destroy(struct vrdma_dpa_vq *dpa_vq)
 
 static void vrdma_dpa_vq_destroy(struct snap_vrdma_queue *virtq)
 {
+	TAILQ_REMOVE(&virtq->ctrl->virtqs, virtq, vq);
 	_vrdma_dpa_vq_destroy(virtq->dpa_vq);
 	snap_dma_ep_destroy(virtq->dma_q);
+	free(virtq);
 }
 
 static void vrdma_dpa_vq_dump_attribute(struct snap_dma_q_create_attr *rdma_qp_create_attr,
@@ -853,7 +855,6 @@ vrdma_dpa_vq_create(struct vrdma_ctrl *ctrl, struct spdk_vrdma_qp *vqp,
 	attr.rx_qsize     = q_attr->rq_size;
 	attr.tx_elem_size = q_attr->tx_elem_size;
 	attr.rx_elem_size = q_attr->rx_elem_size;
-;
 	/*prepare mkey && pd */
 	attr.emu_ib_ctx  = ctrl->emu_ctx;
 	attr.emu_pd      = ctrl->pd;
@@ -919,9 +920,10 @@ vrdma_dpa_vq_create(struct vrdma_ctrl *ctrl, struct spdk_vrdma_qp *vqp,
 	return virtq;
 err_post_recv:
 err_ep_connect:
-	vrdma_dpa_vq_destroy(virtq);
+	_vrdma_dpa_vq_destroy(virtq->dpa_vq);
 err_vq_create:
 	snap_dma_ep_destroy(virtq->dma_q);
+	free(virtq);
 	return NULL;
 }
 


### PR DESCRIPTION
…missed freed 3. Without vq remote frome list after deleted.