### PR TITLE
snap_rpc: for test must add parameter -j <local_sf_dev_mac> for mqp c…

### DIFF
--- a/app/spdk_vrdma/README.md
+++ b/app/spdk_vrdma/README.md
@@ -139,9 +139,9 @@ ifconfig enp3s0f0s0 100.10.20.2/24
 #Run RPC on ARM to configure SF for traffic
 
 <spdk_vrdma_view>snap-rdma/rpc/snap_rpc.py controller_vrdma_configue -d <dev_id> -e mlx5_0 -r <remote-arm-ip> -o <local-arm-ip> -n <local sf-dev> -t <local sf-dev mtu>
--c <remote_sf_dev_mac> -u <ipv4 addr of peer sf> -i <ipv4 addr of local sf> -g <source gid id>
+-j <local_sf_dev_mac> -c <remote_sf_dev_mac> -u <ipv4 addr of peer sf> -i <ipv4 addr of local sf> -g <source gid id>
 
-snap-rdma/rpc/snap_rpc.py controller_vrdma_configue -d 0 -e mlx5_0 -r 10.237.121.39  -o 10.237.121.59 -n mlx5_2 -t 1500 -c 62:21:22:31:23:11  -u 100.10.20.1 -i 100.10.20.2 -g 1
+snap-rdma/rpc/snap_rpc.py controller_vrdma_configue -d 0 -e mlx5_0 -r 10.237.121.39  -o 10.237.121.59 -n mlx5_2 -t 1500 -j 62:21:22:31:22:11 -c 62:21:22:31:23:11  -u 100.10.20.1 -i 100.10.20.2 -g 1
 
 How to use DPDK test on host
 =================================


### PR DESCRIPTION
After the mqp coalesce code merged, for test we must add -j <local_sf_dev_mac> for test. The combination of
<local_sf_dev_mac> and <remote_sf_dev_mac> is used to find tgid node pair.