### PR TITLE
when destroy vqp, it may not have an active mqp so need check.

### DIFF
--- a/lib/vrdma/vrdma_qp.c
+++ b/lib/vrdma/vrdma_qp.c
@@ -196,6 +196,8 @@ vrdma_mqp_del_vqp_from_list(struct vrdma_backend_qp *mqp,
 {
     struct vrdma_vqp *vqp_entry = NULL, *tmp;
 
+    SPDK_NOTICELOG("vqp=0x%x, mqp=%p", vqp_idx, mqp);
+    if(!mqp) return;
     LIST_FOREACH_SAFE(vqp_entry, &mqp->vqp_list, entry, tmp) {
         if (vqp_entry->qpn == vqp_idx) {
             LIST_REMOVE(vqp_entry, entry);


### PR DESCRIPTION
vqp->bk_qp is only set when its backend qp is active (in rts state) . There are cases when destroy vqp, its mqp is not active. Hence add check to avoid crash.